### PR TITLE
from aioredis change to redis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,9 +89,9 @@ using as so,
     redis_store = RedisStore(address)
     RateLimiter(app, store=redis_store)
 
-This store uses `aioredis <https://github.com/aio-libs/aioredis>`_,
+This store uses `redis <https://github.com/redis/redis-py>`_,
 and any extra keyword arguments passed to the ``RedisStore``
-constructor will be passed to the aioredis ``create_redis`` function.
+constructor will be passed to the redis ``create_redis`` function.
 
 A custom store is possible, see the ``RateLimiterStoreABC`` for the
 required interface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,13 +58,13 @@ warn_unused_ignores = true
 [tool.poetry.dependencies]
 python = ">=3.7"
 quart = ">=0.15"
-aioredis = { version = ">=2.0", optional = true }
+redis = { version = ">=4.4.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 tox = "*"
 
 [tool.poetry.extras]
-redis = ["aioredis"]
+redis = ["redis"]
 
 [tool.pytest.ini_options]
 addopts = "--no-cov-on-fail --showlocals --strict-markers"

--- a/src/quart_rate_limiter/redis_store.py
+++ b/src/quart_rate_limiter/redis_store.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Optional
 
-import aioredis
+from redis import asyncio as aioredis
 
 from .store import RateLimiterStoreABC
 
@@ -12,7 +12,7 @@ class RedisStore(RateLimiterStoreABC):
     Arguments:
         address: The address of the redis instance.
         kwargs: Any keyword arguments to pass to the redis client on
-            creation, see the aioredis documentation.
+            creation, see the redis documentation.
     """
 
     def __init__(self, address: str, **kwargs: Any) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ isolated_build = True
 
 [testenv]
 deps =
-    aioredis
+    redis
     pytest
     pytest-asyncio
     pytest-cov
@@ -14,7 +14,7 @@ commands = pytest --cov=quart_rate_limiter {posargs}
 [testenv:redis]
 basepython = python3.10
 deps =
-    aioredis
+    redis
     pytest
     pytest-asyncio
     pytest-cov
@@ -41,7 +41,7 @@ commands = flake8 src/quart_rate_limiter/ tests/
 [testenv:mypy]
 basepython = python3.10
 deps =
-    aioredis
+    redis
     mypy
     pytest
 commands =


### PR DESCRIPTION
aioredis is no longer maintained, so switch to redis

[https://github.com/redis/redis-py/releases/tag/v4.2.0rc1](https://github.com/redis/redis-py/releases/tag/v4.2.0rc1)

[PR](https://github.com/aio-libs/aioredis-py/issues/1443)