### PR TITLE
Support Valkey as an alternative store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,24 @@ jobs:
       - run: pip install tox
 
       - run: tox -e redis
+
+  valkey-tox:
+    runs-on: ubuntu-latest
+
+    container: python:3.13
+
+    services:
+      valkey:
+        image: valkey/valkey
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: pip install tox
+
+      - run: tox -e valkey

--- a/docs/how_to_guides/store.rst
+++ b/docs/how_to_guides/store.rst
@@ -7,8 +7,12 @@ multiple instances together will allow a higher overall limit. To
 avoid this you can centralise the store so that all instances use the
 same store and hence limits.
 
+Redis store
+-----------
+
 Quart-Rate-Limiter has a builtin interface to use a redis store which
-can be used as so,
+can be used after installing Quart-Rate-Limiter with the ``redis``
+extension, ``pip install quart-rate-limiter[redis]``, as so,
 
 .. code-block:: python
 
@@ -16,6 +20,21 @@ can be used as so,
 
     redis_store = RedisStore("address")
     RateLimiter(app, store=redis_store)
+
+
+Valkey store
+------------
+
+Quart-Rate-Limiter has a builtin interface to use a valkey store which
+can be used after installing Quart-Rate-Limiter with the ``valkey``
+extension, ``pip install quart-rate-limiter[valkey]``, as so,
+
+.. code-block:: python
+
+    from quart_rate_limiter.valkey_store import valkeyStore
+
+    valkey_store = valkeyStore("address")
+    RateLimiter(app, store=valkey_store)
 
 Custom store
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ requires-python = ">=3.9"
 [project.optional-dependencies]
 docs = ["pydata_sphinx_theme"]
 redis = ["redis >= 4.4.0"]
+valkey = ["valkey"]
 
 [tool.black]
 line-length = 100

--- a/src/quart_rate_limiter/valkey_store.py
+++ b/src/quart_rate_limiter/valkey_store.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from typing import Any, Optional
+
+import valkey.asyncio as valkey
+
+from .store import RateLimiterStoreABC
+
+
+class ValkeyStore(RateLimiterStoreABC):
+    """An Valkey backed store of rate limits.
+
+    Arguments:
+        address: The address of the valkey instance.
+        kwargs: Any keyword arguments to pass to the valkey client on
+            creation, see the valkey-py documentation.
+    """
+
+    def __init__(self, address: str, **kwargs: Any) -> None:
+        self._valkey: Optional[valkey.Valkey] = None
+        self._valkey_arguments = (address, kwargs)
+
+    async def before_serving(self) -> None:
+        self._valkey = valkey.from_url(self._valkey_arguments[0], **self._valkey_arguments[1])
+
+    async def get(self, key: str, default: datetime) -> datetime:
+        result = await self._valkey.get(key)
+        if result is None:
+            return default
+        else:
+            return datetime.fromtimestamp(float(result))
+
+    async def set(self, key: str, tat: datetime) -> None:
+        await self._valkey.set(key, tat.timestamp())
+
+    async def after_serving(self) -> None:
+        await self._valkey.aclose()
+        self._valkey = None

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     pytest-asyncio
     pytest-cov
     pytest-sugar
+    valkey
 commands = pytest --cov=quart_rate_limiter {posargs}
 
 [testenv:redis]
@@ -19,7 +20,19 @@ deps =
     pytest-asyncio
     pytest-cov
     pytest-sugar
+    valkey
 commands = pytest --cov=quart_rate_limiter --redis-host="redis" {posargs}
+
+[testenv:valkey]
+basepython = python3.13
+deps =
+    redis
+    pytest
+    pytest-asyncio
+    pytest-cov
+    pytest-sugar
+    valkey
+commands = pytest --cov=quart_rate_limiter --valkey-host="valkey" {posargs}
 
 [testenv:docs]
 basepython = python3.13
@@ -53,6 +66,7 @@ deps =
     redis
     mypy
     pytest
+    valkey
 commands =
     mypy src/quart_rate_limiter/ tests/
 


### PR DESCRIPTION
Valkey looks to be a useful alternative to Redis and hence this support allows Quart-Rate-Limiter to use it in the same way.