### PR TITLE
Enforces timezone-aware `datetime`s

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def _fixed_datetime(monkeypatch: MonkeyPatch) -> datetime:
     class MockDatetime(datetime):
         @classmethod
         def now(cls, tz) -> datetime:  # type: ignore
-            return datetime(2019, 3, 4)
+            return datetime(2019, 3, 4, tzinfo=tz)
 
     monkeypatch.setattr(quart_rate_limiter, "datetime", MockDatetime)
     return MockDatetime.now(timezone.utc)


### PR DESCRIPTION
A suggestion to fix #13. The logic is:

* After 108f576a47cfa1a04c6f914407d7609ec40b017d all `datetime`s representing _now_ are timezone-aware
* As described in the issue linked above, the `datetime` stored might not be be timezone-aware
* Python does not compare a naive `datetime` with a timezone-aware `datetime`
* Thus, this PR suggests assuming UTC for naive `datetime`s coming from the storage